### PR TITLE
docs: fix cost-example token math + Mermaid dark-mode legibility

### DIFF
--- a/docs/guides/ai-for-security-leaders.md
+++ b/docs/guides/ai-for-security-leaders.md
@@ -81,8 +81,8 @@ flowchart TD
     D1 -->|Organizational| D2["Address shifts,<br/>scope, priorities"]
     D1 -->|Volume| D3["AI triage<br/>may reduce toil"]
 
-    classDef ai fill:#bbf7d0,stroke:#15803d;
-    classDef first fill:#fde68a,stroke:#b45309;
+    classDef ai fill:#bbf7d0,stroke:#15803d,color:#0f172a;
+    classDef first fill:#fde68a,stroke:#b45309,color:#0f172a;
     class A3,B3,C3,D3 ai;
     class A2,B2,C2,D2 first;
 ```
@@ -174,10 +174,10 @@ flowchart LR
     A["Evaluating<br/>use cases<br/>~22%"] --> B["Targeted<br/>pilots<br/>~34%"]
     B --> C["AI across<br/>multiple workflows<br/>~31%"]
     C -.-> D["Measured ROI<br/>+ governance<br/>(your goal)"]
-    style A fill:#e2e8f0,stroke:#475569
-    style B fill:#bfdbfe,stroke:#1d4ed8
-    style C fill:#bbf7d0,stroke:#15803d
-    style D fill:#fde68a,stroke:#b45309,stroke-dasharray: 4 3
+    style A fill:#e2e8f0,stroke:#475569,color:#0f172a
+    style B fill:#bfdbfe,stroke:#1d4ed8,color:#0f172a
+    style C fill:#bbf7d0,stroke:#15803d,color:#0f172a
+    style D fill:#fde68a,stroke:#b45309,color:#0f172a,stroke-dasharray: 4 3
 ```
 
 *(The dashed final state is the operating goal, not a bucket Gurucul measures.)*

--- a/docs/guides/ai-for-security-leaders.md
+++ b/docs/guides/ai-for-security-leaders.md
@@ -226,8 +226,8 @@ Assume **2,500 alerts/day** and a triage prompt of roughly **3K input + 500 outp
 
 | Approach | Tokens/day (rough) | Illustrative monthly cost\* | Notes |
 | --- | --- | --- | --- |
-| **LLM on every alert** | ~8.75M in / 1.25M out | **$$$** | Simplest, but you pay to read noise |
-| **Hybrid: ML filter → LLM** | ~2.6M in / 0.4M out (after ~70% filtered) | **~⅓ of above** | The ML pre-filter is near-free per prediction |
+| **LLM on every alert** | ~7.5M in / 1.25M out | **$$$** | Simplest, but you pay to read noise |
+| **Hybrid: ML filter → LLM** | ~2.25M in / 0.38M out (after ~70% filtered) | **~⅓ of above** | The ML pre-filter is near-free per prediction |
 | **Local / open-source model** | n/a (self-hosted) | Infra + ops time, no per-token fee | Best for sensitive data; you own the GPUs and tuning |
 
 \* *Multiply your tokens by the model's per-million input/output price. A cheaper mid-tier model can be 10–20× less than a frontier model for the same volume — so **routing easy alerts to a small model and only escalating hard ones to a frontier model** is often the biggest single cost lever.*


### PR DESCRIPTION
Two small, independent correctness fixes to `docs/guides/ai-for-security-leaders.md`.

## 1. Input-token math in the cost example
The "What It Actually Costs" table conflated **total** tokens with **input** tokens. At 2,500 alerts/day × (3K in + 500 out):
- "LLM on every alert" input was `8.75M` — but that's the *total* (7.5M in + 1.25M out). → corrected to **7.5M in**.
- "Hybrid" input was `2.6M` — the ~2.63M *total* for the 750 surviving alerts. → corrected to **2.25M in / 0.38M out**.

Output figures and the "~⅓ of above" cost ratio were already correct and are unchanged. (Verified arithmetically.)

## 2. Mermaid dark-mode legibility
The two **flowcharts** (decision tree, maturity curve) hardcode light pastel node fills. In GitHub **dark mode**, Mermaid sets label text to light grey → light-text-on-light-fill (effectively unreadable). I rendered both diagrams under `theme:dark` to confirm, then pinned `color:#0f172a` on every styled node so label text stays dark on the pastel fills in **both** themes.

The `quadrantChart` and `timeline` already use theme-adaptive colors and were verified fine — no change needed.

## Validation
- Re-rendered/validated all 4 Mermaid diagrams (light + dark); dark render now emits `fill:#0f172a !important` on styled-node labels.
- 971 doc tests pass (`test_curriculum_integrity`, `TestMarkdownValidity`); freshness checks green; diagram count unchanged (4).

https://claude.ai/code/session_01YTtpGM4qCLwFouJchxVuY2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTtpGM4qCLwFouJchxVuY2)_